### PR TITLE
PS-1553 Move `dataDir` to ProviderInitializer constructor

### DIFF
--- a/src/AbstractProviderInitializer.php
+++ b/src/AbstractProviderInitializer.php
@@ -16,21 +16,25 @@ abstract class AbstractProviderInitializer
 
     /** @var WorkspaceProviderFactoryInterface */
     private $workspaceProviderFactory;
+    
+    /** @var string */
+    private $dataDirectory;
 
     public function __construct(
         InputStrategyFactory $stagingFactory,
-        WorkspaceProviderFactoryInterface $workspaceProviderFactory
+        WorkspaceProviderFactoryInterface $workspaceProviderFactory,
+        $dataDirectory
     ) {
         $this->stagingFactory = $stagingFactory;
         $this->workspaceProviderFactory = $workspaceProviderFactory;
+        $this->dataDirectory = $dataDirectory;
     }
 
     /**
      * @param string $stagingType
      * @param array $tokenInfo
-     * @param string $dataDirectory
      */
-    abstract public function initializeProviders($stagingType, array $tokenInfo, $dataDirectory);
+    abstract public function initializeProviders($stagingType, array $tokenInfo);
 
     /**
      * @param class-string<WorkspaceStagingInterface> $workspaceClass
@@ -43,13 +47,12 @@ abstract class AbstractProviderInitializer
     }
 
     /**
-     * @param string $dataDirectory
      * @param array<string, Scope> $scopes
      */
-    protected function addLocalProvider($dataDirectory, $scopes)
+    protected function addLocalProvider($scopes)
     {
-        $stagingProvider = new LocalStagingProvider(function () use ($dataDirectory) {
-            return new LocalStaging($dataDirectory);
+        $stagingProvider = new LocalStagingProvider(function () {
+            return new LocalStaging($this->dataDirectory);
         });
 
         $this->stagingFactory->addProvider($stagingProvider, $scopes);

--- a/src/InputProviderInitializer.php
+++ b/src/InputProviderInitializer.php
@@ -13,8 +13,7 @@ class InputProviderInitializer extends AbstractProviderInitializer
 {
     public function initializeProviders(
         $stagingType,
-        array $tokenInfo,
-        $dataDirectory
+        array $tokenInfo
     ) {
         if ($stagingType === InputStrategyFactory::WORKSPACE_REDSHIFT &&
             $tokenInfo['owner']['hasRedshift']
@@ -61,7 +60,6 @@ class InputProviderInitializer extends AbstractProviderInitializer
         }
 
         $this->addLocalProvider(
-            $dataDirectory,
             [
                 InputStrategyFactory::LOCAL => new Scope([Scope::FILE_DATA, Scope::FILE_METADATA, Scope::TABLE_DATA, Scope::TABLE_METADATA]),
                 // TABLE_DATA for ABS and S3 is bound to LocalProvider because it requires no provider at all

--- a/src/OutputProviderInitializer.php
+++ b/src/OutputProviderInitializer.php
@@ -16,7 +16,8 @@ class OutputProviderInitializer extends AbstractProviderInitializer
 {
     public function __construct(
         InputStrategyFactory $stagingFactory,
-        WorkspaceProviderFactoryInterface $workspaceProviderFactory
+        WorkspaceProviderFactoryInterface $workspaceProviderFactory,
+        $dataDirectory
     ) {
         if (!$stagingFactory instanceof OutputStrategyFactory) {
             throw new StagingProviderException(sprintf(
@@ -28,14 +29,14 @@ class OutputProviderInitializer extends AbstractProviderInitializer
 
         parent::__construct(
             $stagingFactory,
-            $workspaceProviderFactory
+            $workspaceProviderFactory,
+            $dataDirectory
         );
     }
 
     public function initializeProviders(
         $stagingType,
-        array $tokenInfo,
-        $dataDirectory
+        array $tokenInfo
     ) {
         if ($stagingType === OutputStrategyFactory::WORKSPACE_REDSHIFT &&
             $tokenInfo['owner']['hasRedshift']
@@ -82,7 +83,6 @@ class OutputProviderInitializer extends AbstractProviderInitializer
         }
         
         $this->addLocalProvider(
-            $dataDirectory,
             [
                 OutputStrategyFactory::LOCAL => new Scope([Scope::FILE_DATA, Scope::FILE_METADATA, Scope::TABLE_DATA, Scope::TABLE_METADATA]),
                 OutputStrategyFactory::WORKSPACE_REDSHIFT => new Scope([Scope::FILE_DATA, Scope::FILE_METADATA, Scope::TABLE_METADATA]),

--- a/tests/CombinedProviderInitializerTest.php
+++ b/tests/CombinedProviderInitializerTest.php
@@ -64,23 +64,21 @@ class CombinedProviderInitializerTest extends TestCase
             );
 
             $inputStagingFactory = new InputStrategyFactory($clientWrapper, $logger, 'json');
-            $inputInitializer = new InputProviderInitializer($inputStagingFactory, $providerFactory);
+            $inputInitializer = new InputProviderInitializer($inputStagingFactory, $providerFactory, '/tmp/random/data');
             $inputInitializer->initializeProviders(
                 InputStrategyFactory::WORKSPACE_SNOWFLAKE,
                 [
                     'owner' => ['hasSnowflake' => true],
-                ],
-                '/tmp/random/data'
+                ]
             );
 
             $outputStagingFactory = new OutputStrategyFactory($clientWrapper, $logger, 'json');
-            $outputInitializer = new OutputProviderInitializer($outputStagingFactory, $providerFactory);
+            $outputInitializer = new OutputProviderInitializer($outputStagingFactory, $providerFactory, '/tmp/random/data');
             $outputInitializer->initializeProviders(
                 OutputStrategyFactory::WORKSPACE_SNOWFLAKE,
                 [
                     'owner' => ['hasSnowflake' => true],
-                ],
-                '/tmp/random/data'
+                ]
             );
 
             $inputStrategy = $inputStagingFactory->getTableInputStrategy(OutputStrategyFactory::WORKSPACE_SNOWFLAKE, 'test', new InputTableStateList([]));

--- a/tests/InputProviderInitializerTest.php
+++ b/tests/InputProviderInitializerTest.php
@@ -45,13 +45,9 @@ class InputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new InputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new InputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
-        $init->initializeProviders(
-            InputStrategyFactory::LOCAL,
-            [],
-            '/tmp/random/data'
-        );
+        $init->initializeProviders(InputStrategyFactory::LOCAL, []);
 
         self::assertInstanceOf(InputFileLocal::class, $stagingFactory->getFileInputStrategy(InputStrategyFactory::LOCAL));
         self::assertInstanceOf(InputTableLocal::class, $stagingFactory->getTableInputStrategy(InputStrategyFactory::LOCAL, '', new InputTableStateList([])));
@@ -85,7 +81,7 @@ class InputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new InputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new InputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             InputStrategyFactory::WORKSPACE_REDSHIFT,
@@ -96,8 +92,7 @@ class InputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'aws',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
 
         self::assertInstanceOf(InputFileLocal::class, $stagingFactory->getFileInputStrategy(InputStrategyFactory::LOCAL));
@@ -130,7 +125,7 @@ class InputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new InputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new InputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             InputStrategyFactory::WORKSPACE_SNOWFLAKE,
@@ -141,8 +136,7 @@ class InputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'aws',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
 
         self::assertInstanceOf(InputFileLocal::class, $stagingFactory->getFileInputStrategy(InputStrategyFactory::LOCAL));
@@ -175,7 +169,7 @@ class InputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new InputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new InputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             InputStrategyFactory::WORKSPACE_SYNAPSE,
@@ -186,8 +180,7 @@ class InputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'azure',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
 
         self::assertInstanceOf(InputFileLocal::class, $stagingFactory->getFileInputStrategy(InputStrategyFactory::LOCAL));
@@ -220,7 +213,7 @@ class InputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new InputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new InputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             InputStrategyFactory::WORKSPACE_ABS,
@@ -231,8 +224,7 @@ class InputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'azure',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
 
         self::assertInstanceOf(InputFileLocal::class, $stagingFactory->getFileInputStrategy(InputStrategyFactory::LOCAL));

--- a/tests/OutputProviderInitializerTest.php
+++ b/tests/OutputProviderInitializerTest.php
@@ -40,12 +40,11 @@ class OutputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new OutputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new OutputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             OutputStrategyFactory::LOCAL,
-            [],
-            '/tmp/random/data'
+            []
         );
         self::assertInstanceOf(OutputFileLocal::class, $stagingFactory->getFileOutputStrategy(OutputStrategyFactory::LOCAL));
         self::assertInstanceOf(AllEncompassingTableStrategy::class, $stagingFactory->getTableOutputStrategy(OutputStrategyFactory::LOCAL));
@@ -75,7 +74,7 @@ class OutputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new OutputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new OutputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             OutputStrategyFactory::WORKSPACE_REDSHIFT,
@@ -86,8 +85,7 @@ class OutputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'azure',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
         self::assertInstanceOf(OutputFileLocal::class, $stagingFactory->getFileOutputStrategy(OutputStrategyFactory::LOCAL));
         self::assertInstanceOf(AllEncompassingTableStrategy::class, $stagingFactory->getTableOutputStrategy(OutputStrategyFactory::LOCAL));
@@ -119,7 +117,7 @@ class OutputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new OutputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new OutputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             OutputStrategyFactory::WORKSPACE_SNOWFLAKE,
@@ -130,8 +128,7 @@ class OutputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'azure',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
         self::assertInstanceOf(OutputFileLocal::class, $stagingFactory->getFileOutputStrategy(OutputStrategyFactory::LOCAL));
         self::assertInstanceOf(AllEncompassingTableStrategy::class, $stagingFactory->getTableOutputStrategy(OutputStrategyFactory::LOCAL));
@@ -163,7 +160,7 @@ class OutputProviderInitializerTest extends TestCase
             'my-test-component',
             'my-test-config'
         );
-        $init = new OutputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new OutputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             OutputStrategyFactory::WORKSPACE_SYNAPSE,
@@ -174,8 +171,7 @@ class OutputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'azure',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
 
         self::assertInstanceOf(OutputFileLocal::class, $stagingFactory->getFileOutputStrategy(OutputStrategyFactory::LOCAL));
@@ -229,7 +225,7 @@ class OutputProviderInitializerTest extends TestCase
             'keboola.runner-workspace-abs-test',
             'my-test-config'
         );
-        $init = new OutputProviderInitializer($stagingFactory, $providerFactory);
+        $init = new OutputProviderInitializer($stagingFactory, $providerFactory, '/tmp/random/data');
 
         $init->initializeProviders(
             OutputStrategyFactory::WORKSPACE_ABS,
@@ -240,8 +236,7 @@ class OutputProviderInitializerTest extends TestCase
                     'hasSnowflake' => true,
                     'fileStorageProvider' => 'azure',
                 ],
-            ],
-            '/tmp/random/data'
+            ]
         );
 
         self::assertInstanceOf(OutputFileLocal::class, $stagingFactory->getFileOutputStrategy(OutputStrategyFactory::LOCAL));

--- a/tests/Provider/WorkspaceStagingProviderTest.php
+++ b/tests/Provider/WorkspaceStagingProviderTest.php
@@ -6,9 +6,7 @@ use Keboola\StorageApi\Workspaces;
 use Keboola\StagingProvider\Exception\StagingProviderException;
 use Keboola\StagingProvider\Provider\WorkspaceStagingProvider;
 use Keboola\StagingProvider\Staging\LocalStaging;
-use Keboola\StagingProvider\Staging\StagingInterface;
 use Keboola\StagingProvider\Staging\Workspace\SnowflakeWorkspaceStaging;
-use Keboola\StagingProvider\Staging\Workspace\WorkspaceStaging;
 use Keboola\StagingProvider\Staging\Workspace\WorkspaceStagingInterface;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-1553

Napadlo me to pri sepisoani dokumentace. Dava mi to daleko vetsi mysl, protoze ten `dataDir` je v podtsate pro `LocalStaging` jako `workspaceStagingFactory` pro factory - resi, jak (s jakymi parametry) se dana kategorie stagingu bude vytvaret. Rozdil jse samozrejme v tom, ze zatim co workspace staging je celkem slozity vytvorit, tak je na nej factory, u local staging je to stupid dimple, takze se predava jen ten parametr `dataDir`.