### PR TITLE
PS-1553 Add StagingProviderInterface

### DIFF
--- a/src/Provider/AbstractStagingProvider.php
+++ b/src/Provider/AbstractStagingProvider.php
@@ -9,7 +9,7 @@ use Keboola\StagingProvider\Staging\StagingInterface;
 /**
  * @template T of StagingInterface
  */
-abstract class AbstractStagingProvider implements ProviderInterface
+abstract class AbstractStagingProvider implements StagingProviderInterface
 {
     /** @var callable */
     private $stagingGetter;

--- a/src/Provider/StagingProviderInterface.php
+++ b/src/Provider/StagingProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Keboola\StagingProvider\Provider;
+
+use Keboola\InputMapping\Staging\ProviderInterface;
+use Keboola\StagingProvider\Staging\StagingInterface;
+
+interface StagingProviderInterface extends ProviderInterface
+{
+    /**
+     * @return StagingInterface
+     */
+    public function getStaging();
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-1553

`data-loader-api` vyuziva primo metodu `AbstractStagingProvider->getStaging()`. Aby se nemuselo zaviset na abstract tride, pridal jsem interface `StagingProviderInterface`, ktery rozsiruje `Keboola\InputMapping\Staging\ProviderInterface` prave o `getStaging()`.